### PR TITLE
Recovery Wallet Smart Contract

### DIFF
--- a/suprow_contract/Clarinet.toml
+++ b/suprow_contract/Clarinet.toml
@@ -35,6 +35,11 @@ path = 'contracts/privacy.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.recovery_wallet]
+path = 'contracts/recovery_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.research]
 path = 'contracts/research.clar'
 clarity_version = 2

--- a/suprow_contract/contracts/recovery_wallet.clar
+++ b/suprow_contract/contracts/recovery_wallet.clar
@@ -1,0 +1,156 @@
+;; Recovery Wallet Smart Contract
+;; Allows recovery by trusted address with time delay
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-not-authorized (err u101))
+(define-constant err-recovery-pending (err u102))
+(define-constant err-no-recovery-pending (err u103))
+(define-constant err-recovery-too-early (err u104))
+(define-constant err-invalid-recovery-address (err u105))
+(define-constant err-insufficient-balance (err u106))
+
+;; Recovery delay in blocks (approximately 24 hours at 10 min/block)
+(define-constant recovery-delay u144)
+
+;; Data Variables
+(define-data-var wallet-owner principal contract-owner)
+(define-data-var recovery-address (optional principal) none)
+(define-data-var recovery-initiated-at (optional uint) none)
+(define-data-var pending-new-owner (optional principal) none)
+
+;; Maps
+(define-map authorized-recovery-addresses principal bool)
+
+;; Read-only functions
+(define-read-only (get-wallet-owner)
+  (var-get wallet-owner))
+
+(define-read-only (get-recovery-address)
+  (var-get recovery-address))
+
+(define-read-only (get-recovery-status)
+  {
+    recovery-initiated-at: (var-get recovery-initiated-at),
+    pending-new-owner: (var-get pending-new-owner),
+    current-block: block-height,
+    recovery-ready: (match (var-get recovery-initiated-at)
+      initiated-at (>= block-height (+ initiated-at recovery-delay))
+      false)
+  })
+
+(define-read-only (is-recovery-authorized (recovery-addr principal))
+  (default-to false (map-get? authorized-recovery-addresses recovery-addr)))
+
+(define-read-only (get-wallet-balance)
+  (stx-get-balance (as-contract tx-sender)))
+
+;; Public functions
+
+;; Set recovery address (only wallet owner)
+(define-public (set-recovery-address (new-recovery-addr principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get wallet-owner)) err-owner-only)
+    (asserts! (not (is-eq new-recovery-addr (var-get wallet-owner))) err-invalid-recovery-address)
+    (var-set recovery-address (some new-recovery-addr))
+    (map-set authorized-recovery-addresses new-recovery-addr true)
+    (ok true)))
+
+;; Remove recovery address (only wallet owner)
+(define-public (remove-recovery-address)
+  (begin
+    (asserts! (is-eq tx-sender (var-get wallet-owner)) err-owner-only)
+    (match (var-get recovery-address)
+      recovery-addr (map-delete authorized-recovery-addresses recovery-addr)
+      true)
+    (var-set recovery-address none)
+    (ok true)))
+
+;; Initiate recovery process (only authorized recovery address)
+(define-public (initiate-recovery (new-owner principal))
+  (begin
+    (asserts! (is-some (var-get recovery-address)) err-not-authorized)
+    (asserts! (is-recovery-authorized tx-sender) err-not-authorized)
+    (asserts! (is-none (var-get recovery-initiated-at)) err-recovery-pending)
+    (asserts! (not (is-eq new-owner (var-get wallet-owner))) err-invalid-recovery-address)
+    
+    (var-set recovery-initiated-at (some block-height))
+    (var-set pending-new-owner (some new-owner))
+    (ok true)))
+
+;; Cancel recovery (only wallet owner)
+(define-public (cancel-recovery)
+  (begin
+    (asserts! (is-eq tx-sender (var-get wallet-owner)) err-owner-only)
+    (asserts! (is-some (var-get recovery-initiated-at)) err-no-recovery-pending)
+    
+    (var-set recovery-initiated-at none)
+    (var-set pending-new-owner none)
+    (ok true)))
+
+;; Complete recovery (only authorized recovery address, after delay)
+(define-public (complete-recovery)
+  (let (
+    (initiated-at (unwrap! (var-get recovery-initiated-at) err-no-recovery-pending))
+    (new-owner (unwrap! (var-get pending-new-owner) err-no-recovery-pending))
+  )
+    (asserts! (is-recovery-authorized tx-sender) err-not-authorized)
+    (asserts! (>= block-height (+ initiated-at recovery-delay)) err-recovery-too-early)
+    
+    ;; Transfer ownership
+    (var-set wallet-owner new-owner)
+    
+    ;; Clear recovery state
+    (var-set recovery-initiated-at none)
+    (var-set pending-new-owner none)
+    
+    ;; Remove old recovery address authorization
+    (match (var-get recovery-address)
+      recovery-addr (map-delete authorized-recovery-addresses recovery-addr)
+      true)
+    (var-set recovery-address none)
+    
+    (ok true)))
+
+;; Deposit STX to wallet
+(define-public (deposit (amount uint))
+  (stx-transfer? amount tx-sender (as-contract tx-sender)))
+
+;; Withdraw STX (only wallet owner)
+(define-public (withdraw (amount uint) (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get wallet-owner)) err-owner-only)
+    (asserts! (<= amount (stx-get-balance (as-contract tx-sender))) err-insufficient-balance)
+    (as-contract (stx-transfer? amount tx-sender recipient))))
+
+;; Emergency withdraw all funds (only wallet owner)
+(define-public (emergency-withdraw (recipient principal))
+  (let ((balance (stx-get-balance (as-contract tx-sender))))
+    (asserts! (is-eq tx-sender (var-get wallet-owner)) err-owner-only)
+    (asserts! (> balance u0) err-insufficient-balance)
+    (as-contract (stx-transfer? balance tx-sender recipient))))
+
+;; Transfer ownership (only wallet owner, immediate)
+(define-public (transfer-ownership (new-owner principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get wallet-owner)) err-owner-only)
+    (asserts! (not (is-eq new-owner (var-get wallet-owner))) err-invalid-recovery-address)
+    
+    ;; Cancel any pending recovery
+    (var-set recovery-initiated-at none)
+    (var-set pending-new-owner none)
+    
+    ;; Transfer ownership
+    (var-set wallet-owner new-owner)
+    (ok true)))
+
+;; Get contract info
+(define-read-only (get-contract-info)
+  {
+    wallet-owner: (var-get wallet-owner),
+    recovery-address: (var-get recovery-address),
+    balance: (stx-get-balance (as-contract tx-sender)),
+    recovery-delay-blocks: recovery-delay,
+    contract-address: (as-contract tx-sender)
+  })

--- a/suprow_contract/tests/recovery_wallet.test.ts
+++ b/suprow_contract/tests/recovery_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Recovery Wallet – README</h1>
<p>A Clarity smart contract for a self-custodial STX wallet that supports <strong>time-delayed social recovery</strong> via an authorized recovery address. It includes deposit/withdrawal flows, ownership transfer, and a clear recovery state machine with safety checks.</p>
<hr>
<h2>Highlights</h2>
<ul>
<li>
<p><strong>Owner-controlled:</strong> A single <code inline="">wallet-owner</code> controls withdrawals and configuration.</p>
</li>
<li>
<p><strong>Designated recovery:</strong> The owner can set a <code inline="">recovery-address</code> that can trigger recovery to a new owner.</p>
</li>
<li>
<p><strong>Delay enforcement:</strong> Recovery completes only after a fixed block delay (<code inline="">recovery-delay = u144</code>, ~24 hours at ~10 min/block).</p>
</li>
<li>
<p><strong>Cancel at any time:</strong> The current owner can cancel a pending recovery before the delay elapses.</p>
</li>
<li>
<p><strong>One-shot reset:</strong> Completing recovery clears the recovery configuration to avoid surprise reuse.</p>
</li>
<li>
<p><strong>Simple funds flow:</strong> <code inline="">deposit</code>, <code inline="">withdraw</code>, and <code inline="">emergency-withdraw</code> use the contract principal to hold STX.</p>
</li>
</ul>
<hr>
<h2>Contract Constants</h2>
<ul>
<li>
<p><code inline="">contract-owner</code> — initialized to <code inline="">tx-sender</code> at deploy/call time for constants; used to seed <code inline="">wallet-owner</code>.</p>
</li>
<li>
<p><code inline="">recovery-delay = u144</code> — the minimum number of blocks from initiation before recovery can complete.</p>
</li>
</ul>
<h3>Error Codes</h3>

Constant | Code | Meaning
-- | -- | --
err-owner-only | u100 | Caller must be the current wallet owner
err-not-authorized | u101 | Caller is not an authorized recovery address or recovery not set
err-recovery-pending | u102 | A recovery has already been initiated
err-no-recovery-pending | u103 | No recovery is currently in progress
err-recovery-too-early | u104 | Recovery delay has not elapsed
err-invalid-recovery-address | u105 | Invalid new owner/recovery address (e.g., equals current owner)
err-insufficient-balance | u106 | Contract balance is too low


<hr>
<h2>State &amp; Storage</h2>
<ul>
<li>
<p><strong>Data Vars</strong></p>
<ul>
<li>
<p><code inline="">wallet-owner : principal</code> — current owner (mutable).</p>
</li>
<li>
<p><code inline="">recovery-address : (optional principal)</code> — designated recovery principal (or <code inline="">none</code>).</p>
</li>
<li>
<p><code inline="">recovery-initiated-at : (optional uint)</code> — block-height when recovery was started.</p>
</li>
<li>
<p><code inline="">pending-new-owner : (optional principal)</code> — proposed new owner during recovery.</p>
</li>
</ul>
</li>
<li>
<p><strong>Maps</strong></p>
<ul>
<li>
<p><code inline="">authorized-recovery-addresses : { principal =&gt; bool }</code> — allowlist backing <code inline="">recovery-address</code> checks.</p>
</li>
</ul>
</li>
</ul>
<blockquote>
<p>STX funds are held by the <strong>contract principal</strong> (<code inline="">as-contract tx-sender</code>). Deposits and withdrawals move STX into/out of the contract principal.</p>
</blockquote>
<hr>
<h2>Recovery Flow (State Machine)</h2>
<ol>
<li>
<p><strong>Configure</strong><br>
Owner calls <code inline="">set-recovery-address(principal)</code> → sets <code inline="">recovery-address</code> and marks it authorized.</p>
</li>
<li>
<p><strong>Initiate</strong><br>
Authorized recovery address calls <code inline="">initiate-recovery(new-owner)</code> → records <code inline="">recovery-initiated-at</code> and <code inline="">pending-new-owner</code>. Fails if already pending.</p>
</li>
<li>
<p><strong>Wait</strong><br>
Must wait until <code inline="">block-height &gt;= initiated-at + recovery-delay</code>.</p>
</li>
<li>
<p><strong>Complete</strong><br>
Authorized recovery address calls <code inline="">complete-recovery()</code> after delay → sets <code inline="">wallet-owner = pending-new-owner</code>, clears recovery state, and <strong>removes</strong> the previous <code inline="">recovery-address</code> &amp; authorization.</p>
</li>
<li>
<p><strong>Cancel (optional)</strong><br>
At any time before completion, current owner may call <code inline="">cancel-recovery()</code> to clear pending state.</p>
</li>
<li>
<p><strong>Reconfigure</strong><br>
Post-recovery, the new owner can set a new recovery address if desired.</p>
</li>
</ol>
<hr>
<h2>Function Reference</h2>
<h3>Read-only</h3>
<ul>
<li>
<p><code inline="">get-wallet-owner() -&gt; principal</code><br>
Returns current <code inline="">wallet-owner</code>.</p>
</li>
<li>
<p><code inline="">get-recovery-address() -&gt; (optional principal)</code><br>
Returns the configured <code inline="">recovery-address</code> (if any).</p>
</li>
<li>
<p><code inline="">get-recovery-status() -&gt; { recovery-initiated-at: (optional uint), pending-new-owner: (optional principal), current-block: uint, recovery-ready: bool }</code><br>
<code inline="">recovery-ready</code> is <code inline="">true</code> once the delay has elapsed.</p>
</li>
<li>
<p><code inline="">is-recovery-authorized(recovery-addr: principal) -&gt; bool</code><br>
Checks authorization mapping; defaults to <code inline="">false</code> if missing.</p>
</li>
<li>
<p><code inline="">get-wallet-balance() -&gt; uint</code><br>
Returns contract principal’s STX balance.</p>
</li>
<li>
<p><code inline="">get-contract-info() -&gt; { wallet-owner: principal, recovery-address: (optional principal), balance: uint, recovery-delay-blocks: uint, contract-address: principal }</code></p>
</li>
</ul>
<h3>Public (state-changing)</h3>
<ul>
<li>
<p><code inline="">set-recovery-address(new-recovery-addr: principal) -&gt; (response bool uint)</code><br>
<strong>Owner-only.</strong> Sets recovery address and authorizes it.</p>
</li>
<li>
<p><code inline="">remove-recovery-address() -&gt; (response bool uint)</code><br>
<strong>Owner-only.</strong> Removes current recovery address and its authorization.</p>
</li>
<li>
<p><code inline="">initiate-recovery(new-owner: principal) -&gt; (response bool uint)</code><br>
<strong>Authorized recovery address only.</strong> Starts the delay window toward <code inline="">new-owner</code>.</p>
</li>
<li>
<p><code inline="">cancel-recovery() -&gt; (response bool uint)</code><br>
<strong>Owner-only.</strong> Clears any pending recovery.</p>
</li>
<li>
<p><code inline="">complete-recovery() -&gt; (response bool uint)</code><br>
<strong>Authorized recovery address only.</strong> Requires <code inline="">block-height &gt;= initiated-at + recovery-delay</code>. Transfers ownership and clears/unauthorizes recovery config.</p>
</li>
<li>
<p><code inline="">deposit(amount: uint) -&gt; (response bool uint)</code><br>
Transfers <code inline="">amount</code> from caller to the <strong>contract principal</strong>.</p>
</li>
<li>
<p><code inline="">withdraw(amount: uint, recipient: principal) -&gt; (response bool uint)</code><br>
<strong>Owner-only.</strong> Transfers <code inline="">amount</code> from contract principal to <code inline="">recipient</code>.</p>
</li>
<li>
<p><code inline="">emergency-withdraw(recipient: principal) -&gt; (response bool uint)</code><br>
<strong>Owner-only.</strong> Transfers <strong>entire</strong> contract balance to <code inline="">recipient</code>.</p>
</li>
<li>
<p><code inline="">transfer-ownership(new-owner: principal) -&gt; (response bool uint)</code><br>
<strong>Owner-only.</strong> Immediate ownership change. Clears any pending recovery.</p>
</li>
</ul>
<blockquote>
<p>All public functions return the standard Clarity <code inline="">response</code> type: <code inline="">(ok true)</code> on success or <code inline="">(err uXXX)</code> on failure.</p>
</blockquote>
<hr>
<h2>Usage Examples (Stacks CLI / Clarinet REPL)</h2>
<p><strong>Set recovery address (owner):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet set-recovery-address 'SP3FBR2AGKX...XYZ)
</code></pre>
<p><strong>Initiate recovery (authorized recovery address):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet initiate-recovery 'SP2C2M8V...NEWOWNER)
</code></pre>
<p><strong>Check readiness:</strong></p>
<pre><code class="language-clarity">(read-only-call? .recovery-wallet get-recovery-status)
;; =&gt; { recovery-ready: false/true, ... }
</code></pre>
<p><strong>Complete recovery (after delay):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet complete-recovery)
</code></pre>
<p><strong>Cancel pending recovery (owner):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet cancel-recovery)
</code></pre>
<p><strong>Deposit 10 STX to wallet (caller -&gt; contract):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet deposit u10000000) ; amounts in microstacks
</code></pre>
<p><strong>Withdraw 1 STX to a recipient (owner only):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet withdraw u1000000 'SP...RECIPIENT)
</code></pre>
<p><strong>Emergency withdraw everything (owner only):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet emergency-withdraw 'SP...SAFEVAULT)
</code></pre>
<p><strong>Immediate ownership transfer (owner only):</strong></p>
<pre><code class="language-clarity">(contract-call? .recovery-wallet transfer-ownership 'SP...NEWOWNER)
</code></pre>
<hr>
<h2>Security Considerations</h2>
<ul>
<li>
<p><strong>Recovery key hygiene:</strong> The <code inline="">recovery-address</code> can transfer ownership after the delay; store it securely (e.g., hardware wallet).</p>
</li>
<li>
<p><strong>Delay tuning:</strong> <code inline="">recovery-delay</code> is fixed at <code inline="">u144</code>. If your chain’s block time differs from ~10 minutes, effective wall-clock delay changes accordingly.</p>
</li>
<li>
<p><strong>Phishing window:</strong> Once recovery is initiated, the owner has until the delay expires to cancel it. Monitor <code inline="">get-recovery-status()</code> and consider off-chain alerts.</p>
</li>
<li>
<p><strong>Authorization clearing:</strong> <code inline="">complete-recovery()</code> intentionally clears <code inline="">recovery-address</code> and its authorization to reduce accidental/hostile reuse.</p>
</li>
<li>
<p><strong>No re-entrancy:</strong> Clarity is non-reentrant, but always validate return values from STX transfers (the contract already asserts balances before sending).</p>
</li>
<li>
<p><strong>Balance checks:</strong> Withdrawals verify sufficient contract balance to avoid partial or failed transfers.</p>
</li>
</ul>
<hr>
<h2>Testing Ideas (Clarinet)</h2>
<ul>
<li>
<p><strong>Happy path:</strong> set recovery → initiate → mine <code inline="">recovery-delay</code> blocks → complete → owner updated → recovery cleared.</p>
</li>
<li>
<p><strong>Cancel flow:</strong> initiate → cancel → cannot complete; must re-initiate.</p>
</li>
<li>
<p><strong>Timing guard:</strong> attempt completion before delay → expect <code inline="">err-recovery-too-early</code>.</p>
</li>
<li>
<p><strong>Auth guard:</strong> initiate/complete from non-authorized addr → expect <code inline="">err-not-authorized</code>.</p>
</li>
<li>
<p><strong>Owner guards:</strong> non-owner attempts to set/remove recovery, withdraw, cancel, transfer ownership → expect <code inline="">err-owner-only</code>.</p>
</li>
<li>
<p><strong>Edge cases:</strong></p>
<ul>
<li>
<p>Setting <code inline="">new-owner == wallet-owner</code> → <code inline="">err-invalid-recovery-address</code>.</p>
</li>
<li>
<p>Withdrawing more than balance → <code inline="">err-insufficient-balance</code>.</p>
</li>
<li>
<p>Removing recovery when none set → should still succeed (no-op map delete + set <code inline="">none</code>).</p>
</li>
</ul>
</li>
</ul>
<hr>
<h2>Deployment &amp; Initialization</h2>
<ul>
<li>
<p>Deploy the contract so that the initial <code inline="">wallet-owner</code> is set to the deployer (seeded from <code inline="">contract-owner</code> into the <code inline="">wallet-owner</code> data var).</p>
</li>
<li>
<p>Fund the contract principal (via <code inline="">deposit</code>) to enable withdrawals.</p>
</li>
<li>
<p>Configure <code inline="">recovery-address</code> immediately after deployment.</p>
</li>
</ul>
<hr>
<h2>Upgrades / Migration</h2>
<p>This contract is not upgradable in place. To migrate:</p>
<ol>
<li>
<p>Deploy a new version.</p>
</li>
<li>
<p>As current owner, <code inline="">emergency-withdraw</code> all STX to a safe intermediate account.</p>
</li>
<li>
<p>Re-deposit into the new contract and set its recovery configuration.</p>
</li>
</ol>
<hr>
<h2>API Quick Reference</h2>
<pre><code class="language-text">READ-ONLY
- get-wallet-owner() -&gt; principal
- get-recovery-address() -&gt; (optional principal)
- get-recovery-status() -&gt; { recovery-initiated-at, pending-new-owner, current-block, recovery-ready }
- is-recovery-authorized(principal) -&gt; bool
- get-wallet-balance() -&gt; uint
- get-contract-info() -&gt; { wallet-owner, recovery-address, balance, recovery-delay-blocks, contract-address }

PUBLIC
- set-recovery-address(principal) -&gt; (ok true) / (err u100|u105)
- remove-recovery-address() -&gt; (ok true) / (err u100)
- initiate-recovery(principal) -&gt; (ok true) / (err u101|u102|u105)
- cancel-recovery() -&gt; (ok true) / (err u100|u103)
- complete-recovery() -&gt; (ok true) / (err u101|u103|u104)
- deposit(uint) -&gt; (ok true) / (err uX from stx-transfer?)
- withdraw(uint, principal) -&gt; (ok true) / (err u100|u106)
- emergency-withdraw(principal) -&gt; (ok true) / (err u100|u106)
- transfer-ownership(principal) -&gt; (ok true) / (err u100|u105)
</code></pre>
<hr>
<h2>License</h2>
<p>Add your preferred license (e.g., MIT, Apache-2.0) and attribution here.</p></body></html><!--EndFragment-->
</body>
</html>